### PR TITLE
Feature/update coding standards

### DIFF
--- a/.phpcs.xml
+++ b/.phpcs.xml
@@ -1,64 +1,258 @@
 <?xml version="1.0"?>
-<ruleset name="WordPress Coding Standards">
-	<description>Apply WordPress Coding Standards</description>
+<ruleset name="WebDevStudios Project Plugin Standards">
+	<description>Apply WebDevStudios Project Plugin Standards</description>
 
 	<!-- Set the memory limit to 256M.
 		 For most standard PHP configurations, this means the memory limit will temporarily be raised.
 		 Ref: https://github.com/squizlabs/PHP_CodeSniffer/wiki/Advanced-Usage#specifying-phpini-settings
 	-->
-	<ini name="memory_limit" value="256M"/>
+	<ini name="memory_limit" value="256M" />
 
-	<description>The ruleset for the WDS site documentation plugin</description>
+	<!-- Whenever possible, cache the scan results and re-use those for unchanged files on the next scan -->
+	<arg name="cache" />
 
-	<!-- Only check the PHP files. -->
-	<arg name="extensions" value="php" />
+	<!-- Strip the filepaths down to the relevant bit -->
+	<arg name="basepath" value="./" />
 
-	<!-- Report warnings, but don't block commits -->
-	<config name="ignore_warnings_on_exit" value="1"/>
+	<!-- Check up to 20 files simultaneously -->
+	<arg name="parallel" value="20" />
 
-	<!-- Exclude the Composer Vendor directory. -->
-	<exclude-pattern>/vendor/*</exclude-pattern>
+	<!-- Show sniff codes in all reports -->
+	<arg value="ps" />
 
-	<!-- Exclude the lib Vendors directory. -->
-	<exclude-pattern>/lib/vendors/*</exclude-pattern>
+	<rule ref="WordPress-Core">
+		<exclude name="WordPress.Arrays.MultipleStatementAlignment.DoubleArrowNotAligned" />
 
-	<!-- Exclude the Node Modules directory. -->
-	<exclude-pattern>/node_modules/*</exclude-pattern>
+		<!-- Allow trigger_error, useful in logging -->
+		<exclude name="WordPress.PHP.DevelopmentFunctions.error_log_trigger_error" />
 
-	<!-- Exclude PHPCS directory. -->
-	<exclude-pattern>/phpcs/*</exclude-pattern>
-
-	<!-- Exclude WPCS directory. -->
-	<exclude-pattern>/wpcs/*</exclude-pattern>
-
-	<config name="minimum_supported_wp_version" value="5.2.14"/>
-
-	<!-- WordPress-Core, WordPress-Docs & WordPress-Extra coding standards -->
-	<rule ref="WordPress">
-		<!-- Allow array short syntax. -->
-		<exclude name="Generic.Arrays.DisallowShortArraySyntax" />
+		<!-- Allow ternaries -->
+		<exclude name="WordPress.PHP.DisallowShortTernary" />
 	</rule>
 
-	<!-- Check used textdomain for project -->
+	<!-- Prefer alignment over line length -->
+	<rule ref="WordPress.Arrays.MultipleStatementAlignment">
+		<properties>
+			<property name="maxColumn" value="1000" />
+		</properties>
+	</rule>
+
+	<rule ref="WordPress">
+
+		<!-- Allow [] -->
+		<exclude name="Generic.Arrays.DisallowShortArraySyntax.Found" />
+	</rule>
+
+	<rule ref="WordPress-Docs">
+
+		<!-- Don't require the @package tag, very useless -->
+		<exclude name="Squiz.Commenting.FileComment.MissingPackageTag" />
+
+		<!-- You don't need to end comment with period or punctuation if you don't want to -->
+		<exclude name="Squiz.Commenting.FunctionComment.ParamCommentFullStop" />
+		<exclude name="Squiz.Commenting.FunctionComment.ThrowsNoFullStop" />
+	</rule>
+
+	<rule ref="WordPress-Extra">
+
+		<!-- Forget about how WP core wants file names to look. -->
+		<exclude name="WordPress.Files.FileName"/>
+
+		<!-- Allow array short syntax [Extra] -->
+		<exclude name="Generic.Arrays.DisallowShortArraySyntax" />
+
+		<!-- Allow short prefixes -->
+		<exclude name="WordPress.NamingConventions.PrefixAllGlobals.ShortPrefixPassed" />
+
+		<!-- Don't worry about files that don't contain any code -->
+		<rule ref="Internal.NoCodeFound">
+			<severity>0</severity>
+		</rule>
+
+		<!-- Don't require punctuation after inline comments -->
+		<exclude name="Squiz.Commenting.InlineComment.InvalidEndChar" />
+
+		<!-- Comment punctuation doesn't matter -->
+		<exclude name="Squiz.Commenting.FunctionComment.ParamCommentFullStop" />
+		<exclude name="Squiz.Commenting.FunctionComment.ThrowsNoFullStop" />
+
+		<!-- Allow empty catch statements -->
+		<exclude name="Generic.CodeAnalysis.EmptyStatement.DetectedCatch" />
+
+		<!-- Allow WP global modification -->
+		<exclude name="WordPress.WP.GlobalVariablesOverride.Prohibited" />
+
+		<!-- The nonce sniff almost never works right; just warn -->
+		<rule ref="WordPress.Security.NonceVerification.Missing">
+			<type>warning</type>
+		</rule>
+	</rule>
+
+	<!-- Make missing translator comment (not really useful) -->
+	<rule ref="WordPress.WP.I18n.MissingTranslatorsComment">
+		<severity>0</severity>
+	</rule>
+
+	<!-- Sometimes we need to override globals -->
+	<rule ref="WordPress.WP.GlobalVariablesOverride.OverrideProhibited">
+		<type>warning</type>
+	</rule>
+
+	<!-- The minimum supported WordPress version. This should match what's listed in style.css -->
+	<rule ref="WordPress.WP.DeprecatedFunctions">
+		<properties>
+			<property name="minimum_supported_version" value="5.2.14" />
+		</properties>
+	</rule>
+
+	<!-- Verify that the text_domain is set to the desired text-domain.
+		 Multiple valid text domains can be provided as a comma-delimited list -->
 	<rule ref="WordPress.WP.I18n">
 		<properties>
-			<property name="text_domain" type="array">
-				<element value="wds-site-documentation"/>
+			<property name="text_domain" type="array" value="wds-site-documentation" />
+		</properties>
+	</rule>
+
+	<!-- Disallow long array syntax -->
+	<rule ref="Generic.Arrays.DisallowLongArraySyntax" />
+
+	<!-- Namespacing required for classes -->
+	<rule ref="PSR1.Classes.ClassDeclaration" />
+
+	<!-- Namespacing required for functions -->
+	<rule ref="PSR2.Namespaces.NamespaceDeclaration" />
+
+	<!--
+	Allow the use of for methods that inherit the parents
+	documentation.
+
+	/**
+	 * {@inheritDoc}
+	 */
+
+	See: https://github.com/squizlabs/PHP_CodeSniffer/wiki/Customisable-Sniff-Properties#squiz-sniffs
+	-->
+	<rule ref="Squiz.Commenting.FunctionComment">
+		<properties>
+			<property name="skipIfInheritdoc" value="true" />
+		</properties>
+	</rule>
+
+	<!-- Allow multiple variable assignments, but only outside of conditionals -->
+	<rule ref="Squiz.PHP.DisallowMultipleAssignments">
+		<exclude name="Squiz.PHP.DisallowMultipleAssignments.Found" />
+	</rule>
+
+	<!-- Disallow functions where WordPress has an alternative -->
+	<rule ref="WordPress.WP.AlternativeFunctions">
+		<!-- ...but, allow these: -->
+		<properties>
+			<property name="exclude" type="array">
+				<element value="file_get_contents" />
 			</property>
 		</properties>
 	</rule>
 
-	<!-- Verify that everything in the global namespace is prefixed with a theme specific prefix.
-		 Multiple valid prefixes can be provided as a comma-delimited list. -->
-	<rule ref="WordPress.NamingConventions.PrefixAllGlobals">
+	<!-- Disallow eval() -->
+	<rule ref="Squiz.PHP.Eval"/>
+	<rule ref="Squiz.PHP.Eval.Discouraged">
+		<type>error</type>
+		<message>eval() is a security risk and is not allowed.</message>
+	</rule>
+
+	<!-- Disallow querying more than 100 posts at once. -->
+	<rule ref="WordPress.WP.PostsPerPage" />
+	<rule ref="WordPress.WP.PostsPerPage.posts_per_page_numberposts">
+		<type>warning</type>
+	</rule>
+	<rule ref="WordPress.WP.PostsPerPage.posts_per_page_posts_per_page">
+		<type>warning</type>
+	</rule>
+
+	<!-- Disallow short PHP tags. (From WordPress-Core) -->
+	<rule ref="Generic.PHP.DisallowShortOpenTag">
+		<!-- But, allow short echo, which is now standard. -->
+		<exclude name="Generic.PHP.DisallowShortOpenTag.EchoFound" />
+	</rule>
+
+	<!-- Disallow old-style PHP tags -->
+	<rule ref="Generic.PHP.DisallowAlternativePHPTags" />
+
+	<!-- Require prepared SQL statements. -->
+	<rule ref="WordPress.DB.PreparedSQL" />
+	<rule ref="WordPress.DB.PreparedSQLPlaceholders" />
+
+	<!-- Disallow "development" functions like var_dump/print_r/phpinfo -->
+	<rule ref="WordPress.PHP.DevelopmentFunctions">
+
+		<!-- Allow triggering errors for reporting purposes. -->
+		<exclude name="WordPress.PHP.DevelopmentFunctions.error_log_error_log" />
+		<exclude name="WordPress.PHP.DevelopmentFunctions.error_log_trigger_error" />
+
+		<!-- Set remaining to errors. -->
+		<type>error</type>
+	</rule>
+
+	<!-- Disallow parts of WP which have been deprecated. -->
+	<rule ref="WordPress.WP.DeprecatedFunctions" />
+	<rule ref="WordPress.WP.DeprecatedClasses" />
+	<rule ref="WordPress.WP.DeprecatedParameters" />
+	<rule ref="WordPress.WP.DeprecatedParameterValues" />
+
+	<!-- Disallow parts of WP which have better alternatives. -->
+	<rule ref="WordPress.WP.DiscouragedConstants" />
+	<rule ref="WordPress.WP.DiscouragedFunctions">
 		<properties>
-			<property name="prefixes" type="array" value="wds,wds_docs,WebDevStudios" />
+			<property name="exclude" type="array">
+
+				<!--
+					wp_reset_query() does a different thing to
+					wp_reset_postdata() and should not be discouraged.
+				-->
+				<element value="wp_reset_query" />
+			</property>
 		</properties>
 	</rule>
 
-	<!-- WordPress Core currently supports PHP 5.6+. -->
-	<config name="testVersion" value="7.2-"/>
+	<rule ref="Generic.PHP.Syntax" />
 
-	<!-- Only sniff the plugin. -->
+	<!-- Encourage having only one class/interface/trait per file. -->
+	<rule ref="Generic.Files.OneObjectStructurePerFile">
+		<type>error</type>
+	</rule>
+
+	<!-- Don't show the above error and this duplicate one -->
+	<rule ref="PSR1.Classes.ClassDeclaration.MultipleClasses">
+		<severity>0</severity>
+	</rule>
+
+	<!-- Sets the minimum supported WP version to the last version with the latest patch. -->
+	<config name="minimum_supported_wp_version" value="5.2.14" />
+
+	<!-- Use WordPress PHP Compatibility -->
+	<rule ref="PHPCompatibilityWP" />
+
+	<!-- WordPress Core currently supports PHP 7.4+ -->
+	<config name="testVersion" value="7.4-" />
+
+	<!-- Only sniff PHP files -->
+	<arg name="extensions" value="php" />
+
+	<!-- Only sniff the plugin -->
 	<file>./</file>
+
+	<!-- Don't sniff the following directories or file types -->
+	<exclude-pattern>/build/*</exclude-pattern>
+	<exclude-pattern>/dist/*</exclude-pattern>
+	<exclude-pattern>/cache/*</exclude-pattern>
+	<exclude-pattern>/log/*</exclude-pattern>
+	<exclude-pattern>/node_modules/*</exclude-pattern>
+	<exclude-pattern>/vendor/*</exclude-pattern>
+
+	<!-- Exclude files that shouldn't get linted (for older packages that won't respect extensions) -->
+	<exclude-pattern>*.js</exclude-pattern>
+	<exclude-pattern>*.jsx</exclude-pattern>
+	<exclude-pattern>*.ts</exclude-pattern>
+	<exclude-pattern>*.css</exclude-pattern>
+	<exclude-pattern>*.scss</exclude-pattern>
 </ruleset>

--- a/.phpcs.xml
+++ b/.phpcs.xml
@@ -1,0 +1,64 @@
+<?xml version="1.0"?>
+<ruleset name="WordPress Coding Standards">
+	<description>Apply WordPress Coding Standards</description>
+
+	<!-- Set the memory limit to 256M.
+		 For most standard PHP configurations, this means the memory limit will temporarily be raised.
+		 Ref: https://github.com/squizlabs/PHP_CodeSniffer/wiki/Advanced-Usage#specifying-phpini-settings
+	-->
+	<ini name="memory_limit" value="256M"/>
+
+	<description>The ruleset for the WDS site documentation plugin</description>
+
+	<!-- Only check the PHP files. -->
+	<arg name="extensions" value="php" />
+
+	<!-- Report warnings, but don't block commits -->
+	<config name="ignore_warnings_on_exit" value="1"/>
+
+	<!-- Exclude the Composer Vendor directory. -->
+	<exclude-pattern>/vendor/*</exclude-pattern>
+
+	<!-- Exclude the lib Vendors directory. -->
+	<exclude-pattern>/lib/vendors/*</exclude-pattern>
+
+	<!-- Exclude the Node Modules directory. -->
+	<exclude-pattern>/node_modules/*</exclude-pattern>
+
+	<!-- Exclude PHPCS directory. -->
+	<exclude-pattern>/phpcs/*</exclude-pattern>
+
+	<!-- Exclude WPCS directory. -->
+	<exclude-pattern>/wpcs/*</exclude-pattern>
+
+	<config name="minimum_supported_wp_version" value="5.2.14"/>
+
+	<!-- WordPress-Core, WordPress-Docs & WordPress-Extra coding standards -->
+	<rule ref="WordPress">
+		<!-- Allow array short syntax. -->
+		<exclude name="Generic.Arrays.DisallowShortArraySyntax" />
+	</rule>
+
+	<!-- Check used textdomain for project -->
+	<rule ref="WordPress.WP.I18n">
+		<properties>
+			<property name="text_domain" type="array">
+				<element value="wds-site-documentation"/>
+			</property>
+		</properties>
+	</rule>
+
+	<!-- Verify that everything in the global namespace is prefixed with a theme specific prefix.
+		 Multiple valid prefixes can be provided as a comma-delimited list. -->
+	<rule ref="WordPress.NamingConventions.PrefixAllGlobals">
+		<properties>
+			<property name="prefixes" type="array" value="wds,wds_docs,WebDevStudios" />
+		</properties>
+	</rule>
+
+	<!-- WordPress Core currently supports PHP 5.6+. -->
+	<config name="testVersion" value="7.2-"/>
+
+	<!-- Only sniff the plugin. -->
+	<file>./</file>
+</ruleset>

--- a/.phpcs.xml.dist
+++ b/.phpcs.xml.dist
@@ -1,1 +1,0 @@
-<?xml version="1.0"?><ruleset name="Project"><rule ref="WebDevStudios"/></ruleset>

--- a/composer.json
+++ b/composer.json
@@ -1,9 +1,11 @@
 {
-    "name": "webdevstudios/wds-site-documentation",
-    "description": "A plugin to host site documentation in an easily accessible place in the WordPress dashboard.",
-    "license": "GPL-2.0-or-later",
-    "type": "wordpress-plugin",
-    "require-dev": {
-        "webdevstudios/php-coding-standards": "~1.3.0"
-    }
+  "name": "webdevstudios/wds-site-documentation",
+  "description": "A plugin to host site documentation in an easily accessible place in the WordPress dashboard.",
+  "license": "GPL-2.0-or-later",
+  "type": "wordpress-plugin",
+  "require-dev": {
+    "dealerdirect/phpcodesniffer-composer-installer": "^0.7.1",
+    "phpcompatibility/phpcompatibility-wp": "^2.1.1",
+    "wp-coding-standards/wpcs": "~2.3.0"
+  }
 }

--- a/composer.lock
+++ b/composer.lock
@@ -4,27 +4,27 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "9f2c9acff0d6f68586416c5aea7c3bed",
+    "content-hash": "89ca4e2e38cec925f0780670e62671cd",
     "packages": [],
     "packages-dev": [
         {
             "name": "dealerdirect/phpcodesniffer-composer-installer",
-            "version": "v0.5.0",
+            "version": "v0.7.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/Dealerdirect/phpcodesniffer-composer-installer.git",
-                "reference": "e749410375ff6fb7a040a68878c656c2e610b132"
+                "reference": "fe390591e0241955f22eb9ba327d137e501c771c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/Dealerdirect/phpcodesniffer-composer-installer/zipball/e749410375ff6fb7a040a68878c656c2e610b132",
-                "reference": "e749410375ff6fb7a040a68878c656c2e610b132",
+                "url": "https://api.github.com/repos/Dealerdirect/phpcodesniffer-composer-installer/zipball/fe390591e0241955f22eb9ba327d137e501c771c",
+                "reference": "fe390591e0241955f22eb9ba327d137e501c771c",
                 "shasum": ""
             },
             "require": {
-                "composer-plugin-api": "^1.0",
-                "php": "^5.3|^7",
-                "squizlabs/php_codesniffer": "^2|^3"
+                "composer-plugin-api": "^1.0 || ^2.0",
+                "php": ">=5.3",
+                "squizlabs/php_codesniffer": "^2.0 || ^3.0 || ^4.0"
             },
             "require-dev": {
                 "composer/composer": "*",
@@ -71,20 +71,180 @@
                 "stylecheck",
                 "tests"
             ],
-            "time": "2018-10-26T13:21:45+00:00"
+            "time": "2020-12-07T18:04:37+00:00"
         },
         {
-            "name": "squizlabs/php_codesniffer",
-            "version": "3.5.8",
+            "name": "phpcompatibility/php-compatibility",
+            "version": "9.3.5",
             "source": {
                 "type": "git",
-                "url": "https://github.com/squizlabs/PHP_CodeSniffer.git",
-                "reference": "9d583721a7157ee997f235f327de038e7ea6dac4"
+                "url": "https://github.com/PHPCompatibility/PHPCompatibility.git",
+                "reference": "9fb324479acf6f39452e0655d2429cc0d3914243"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/squizlabs/PHP_CodeSniffer/zipball/9d583721a7157ee997f235f327de038e7ea6dac4",
-                "reference": "9d583721a7157ee997f235f327de038e7ea6dac4",
+                "url": "https://api.github.com/repos/PHPCompatibility/PHPCompatibility/zipball/9fb324479acf6f39452e0655d2429cc0d3914243",
+                "reference": "9fb324479acf6f39452e0655d2429cc0d3914243",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3",
+                "squizlabs/php_codesniffer": "^2.3 || ^3.0.2"
+            },
+            "conflict": {
+                "squizlabs/php_codesniffer": "2.6.2"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "~4.5 || ^5.0 || ^6.0 || ^7.0"
+            },
+            "suggest": {
+                "dealerdirect/phpcodesniffer-composer-installer": "^0.5 || This Composer plugin will sort out the PHPCS 'installed_paths' automatically.",
+                "roave/security-advisories": "dev-master || Helps prevent installing dependencies with known security issues."
+            },
+            "type": "phpcodesniffer-standard",
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "LGPL-3.0-or-later"
+            ],
+            "authors": [
+                {
+                    "name": "Wim Godden",
+                    "homepage": "https://github.com/wimg",
+                    "role": "lead"
+                },
+                {
+                    "name": "Juliette Reinders Folmer",
+                    "homepage": "https://github.com/jrfnl",
+                    "role": "lead"
+                },
+                {
+                    "name": "Contributors",
+                    "homepage": "https://github.com/PHPCompatibility/PHPCompatibility/graphs/contributors"
+                }
+            ],
+            "description": "A set of sniffs for PHP_CodeSniffer that checks for PHP cross-version compatibility.",
+            "homepage": "http://techblog.wimgodden.be/tag/codesniffer/",
+            "keywords": [
+                "compatibility",
+                "phpcs",
+                "standards"
+            ],
+            "time": "2019-12-27T09:44:58+00:00"
+        },
+        {
+            "name": "phpcompatibility/phpcompatibility-paragonie",
+            "version": "1.3.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/PHPCompatibility/PHPCompatibilityParagonie.git",
+                "reference": "ddabec839cc003651f2ce695c938686d1086cf43"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/PHPCompatibility/PHPCompatibilityParagonie/zipball/ddabec839cc003651f2ce695c938686d1086cf43",
+                "reference": "ddabec839cc003651f2ce695c938686d1086cf43",
+                "shasum": ""
+            },
+            "require": {
+                "phpcompatibility/php-compatibility": "^9.0"
+            },
+            "require-dev": {
+                "dealerdirect/phpcodesniffer-composer-installer": "^0.7",
+                "paragonie/random_compat": "dev-master",
+                "paragonie/sodium_compat": "dev-master"
+            },
+            "suggest": {
+                "dealerdirect/phpcodesniffer-composer-installer": "^0.7 || This Composer plugin will sort out the PHP_CodeSniffer 'installed_paths' automatically.",
+                "roave/security-advisories": "dev-master || Helps prevent installing dependencies with known security issues."
+            },
+            "type": "phpcodesniffer-standard",
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "LGPL-3.0-or-later"
+            ],
+            "authors": [
+                {
+                    "name": "Wim Godden",
+                    "role": "lead"
+                },
+                {
+                    "name": "Juliette Reinders Folmer",
+                    "role": "lead"
+                }
+            ],
+            "description": "A set of rulesets for PHP_CodeSniffer to check for PHP cross-version compatibility issues in projects, while accounting for polyfills provided by the Paragonie polyfill libraries.",
+            "homepage": "http://phpcompatibility.com/",
+            "keywords": [
+                "compatibility",
+                "paragonie",
+                "phpcs",
+                "polyfill",
+                "standards"
+            ],
+            "time": "2021-02-15T10:24:51+00:00"
+        },
+        {
+            "name": "phpcompatibility/phpcompatibility-wp",
+            "version": "2.1.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/PHPCompatibility/PHPCompatibilityWP.git",
+                "reference": "d55de55f88697b9cdb94bccf04f14eb3b11cf308"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/PHPCompatibility/PHPCompatibilityWP/zipball/d55de55f88697b9cdb94bccf04f14eb3b11cf308",
+                "reference": "d55de55f88697b9cdb94bccf04f14eb3b11cf308",
+                "shasum": ""
+            },
+            "require": {
+                "phpcompatibility/php-compatibility": "^9.0",
+                "phpcompatibility/phpcompatibility-paragonie": "^1.0"
+            },
+            "require-dev": {
+                "dealerdirect/phpcodesniffer-composer-installer": "^0.7"
+            },
+            "suggest": {
+                "dealerdirect/phpcodesniffer-composer-installer": "^0.7 || This Composer plugin will sort out the PHP_CodeSniffer 'installed_paths' automatically.",
+                "roave/security-advisories": "dev-master || Helps prevent installing dependencies with known security issues."
+            },
+            "type": "phpcodesniffer-standard",
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "LGPL-3.0-or-later"
+            ],
+            "authors": [
+                {
+                    "name": "Wim Godden",
+                    "role": "lead"
+                },
+                {
+                    "name": "Juliette Reinders Folmer",
+                    "role": "lead"
+                }
+            ],
+            "description": "A ruleset for PHP_CodeSniffer to check for PHP cross-version compatibility issues in projects, while accounting for polyfills provided by WordPress.",
+            "homepage": "http://phpcompatibility.com/",
+            "keywords": [
+                "compatibility",
+                "phpcs",
+                "standards",
+                "wordpress"
+            ],
+            "time": "2021-12-30T16:37:40+00:00"
+        },
+        {
+            "name": "squizlabs/php_codesniffer",
+            "version": "3.6.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/squizlabs/PHP_CodeSniffer.git",
+                "reference": "5e4e71592f69da17871dba6e80dd51bce74a351a"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/squizlabs/PHP_CodeSniffer/zipball/5e4e71592f69da17871dba6e80dd51bce74a351a",
+                "reference": "5e4e71592f69da17871dba6e80dd51bce74a351a",
                 "shasum": ""
             },
             "require": {
@@ -122,51 +282,7 @@
                 "phpcs",
                 "standards"
             ],
-            "time": "2020-10-23T02:01:07+00:00"
-        },
-        {
-            "name": "webdevstudios/php-coding-standards",
-            "version": "1.3.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/WebDevStudios/php-coding-standards.git",
-                "reference": "0896147c2e12ffaebf67fb5a9d49b1514e2ccec3"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/WebDevStudios/php-coding-standards/zipball/0896147c2e12ffaebf67fb5a9d49b1514e2ccec3",
-                "reference": "0896147c2e12ffaebf67fb5a9d49b1514e2ccec3",
-                "shasum": ""
-            },
-            "require": {
-                "dealerdirect/phpcodesniffer-composer-installer": "^0.5.0",
-                "wp-coding-standards/wpcs": "~2.3.0"
-            },
-            "type": "phpcodesniffer-standard",
-            "extra": {
-                "phpcodesniffer-search-depth": 5
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "GPL-2.0+"
-            ],
-            "authors": [
-                {
-                    "name": "WebDevStudios",
-                    "email": "contact@webdevstudios.com",
-                    "homepage": "http://webdevstudios.com",
-                    "role": "Company"
-                },
-                {
-                    "name": "Aubrey Portwood",
-                    "email": "aubrey@webdevstudios.com",
-                    "homepage": "http://twitter.com/aubreypwd",
-                    "role": "Project Lead & Developer"
-                }
-            ],
-            "description": "In-house PHP linting and coding standards for WebDevStudios",
-            "homepage": "https://github.com/WebDevStudios/php-coding-standards",
-            "time": "2020-11-16T21:56:03+00:00"
+            "time": "2021-12-12T21:44:58+00:00"
         },
         {
             "name": "wp-coding-standards/wpcs",

--- a/wds-site-documentation.php
+++ b/wds-site-documentation.php
@@ -12,7 +12,7 @@
  * Plugin Name:       WDS Site Documentation
  * Plugin URI:        https://github.com/webdevstudios/wds-site-documentation
  * Description:       A plugin to host site documentation in an easily accessible place in the WordPress dashboard.
- * Version:           1.0.0
+ * Version:           1.1.0-dev
  * Requires at least: 5.2
  * Requires PHP:      7.2
  * Author:            WebDevStudios
@@ -61,13 +61,13 @@ function wds_documentation_dashboard() {
 		// Save attachment ID.
 		if ( isset( $_POST['submit_selectors'] ) ) {
 			check_admin_referer( 'wds_documentation_update', 'wds_documentation_update_nonce' );
-			update_option( 'wds_documentation_video_id', absint( $_POST['wds_documentation_video_id'] ) );
-			update_option( 'wds_documentation_pdf_id', absint( $_POST['wds_documentation_pdf_id'] ) );
+			update_option( 'wds_documentation_video_id', absint( $_POST['wds_documentation_video_id'] ?? 0 ) );
+			update_option( 'wds_documentation_pdf_id', absint( $_POST['wds_documentation_pdf_id'] ?? 0 ) );
 		}
 
 		wp_enqueue_media();
 	}
-?>
+	?>
 	<h1><?php esc_html_e( 'Everything You Need to Know About Your WordPress Website', 'wds-site-documentation' ); ?></h1>
 
 	<p><a href="https://webdevstudios.com/"><img src="<?php echo esc_url( $img_url ); ?>" style="max-width:100%;height:auto;" alt="WebDevStudios"></a></p>
@@ -93,7 +93,7 @@ function wds_documentation_dashboard() {
 		<?php media_selector_print_scripts(); ?>
 	<?php endif; ?>
 
-<?php
+	<?php
 }
 
 add_action( 'admin_menu', __NAMESPACE__ . '\add_wds_documentation_dashboard_page' );
@@ -107,14 +107,16 @@ add_action( 'admin_menu', __NAMESPACE__ . '\add_wds_documentation_dashboard_page
  * @param Object $admin_bar Admin bar object from WordPress.
  */
 function add_toolbar_items( $admin_bar ) {
-	$admin_bar->add_menu( [
-		'id'    => 'wds-documentation',
-		'title' => 'Site Documentation',
-		'href'  => '/wp-admin/admin.php?page=wds_documentation',
-		'meta'  => [
-			'title' => __( 'Documentation', 'wds-site-documentation' ),
-		],
-	] );
+	$admin_bar->add_menu(
+		[
+			'id'    => 'wds-documentation',
+			'title' => 'Site Documentation',
+			'href'  => '/wp-admin/admin.php?page=wds_documentation',
+			'meta'  => [
+				'title' => __( 'Documentation', 'wds-site-documentation' ),
+			],
+		]
+	);
 }
 add_action( 'admin_bar_menu', __NAMESPACE__ . '\add_toolbar_items', 100 );
 
@@ -137,11 +139,11 @@ add_action( 'wp_dashboard_setup', __NAMESPACE__ . '\add_widget' );
  */
 function wds_documentation_widget() {
 	$img_url = plugin_dir_url( __FILE__ ) . '/wds_banner.png';
-?>
+	?>
 
-<?php display_documentation(); ?>
+	<?php display_documentation(); ?>
 
-<?php
+	<?php
 }
 
 /**
@@ -175,7 +177,7 @@ function display_documentation() {
 		'<p>If you need assistance, would like to add more functionality to your site, or require a new redesign, please contact WebDevStudios.</p>
 		<p><a href="https://webdevstudios.com/contact/" class="button button-primary" style="background-color: #f3713c; border-color: #f3713c">Contact WebDevStudios Now</a></p>'
 	);
-?>
+	?>
 	<?php if ( $video_url ) : ?>
 		<p>
 			<?php esc_html_e( 'Watch a video tutorial of how your website works:', 'wds-site-documentation' ); ?><br>
@@ -205,7 +207,7 @@ function display_documentation() {
 	<?php endif; ?>
 
 	<?php echo wp_kses_post( $footer ); ?>
-<?php
+	<?php
 }
 
 /**


### PR DESCRIPTION
Update PHPCS to use the WordPress coding standards. This plugin previously used the [WebDevStudios PHP coding standards which have been depreciated](https://github.com/WebDevStudios/php-coding-standards) in favor of WordPress' standards.

No link/screenshot; code style changes only.